### PR TITLE
Don't allow _ in machine names

### DIFF
--- a/kmaas.py
+++ b/kmaas.py
@@ -296,6 +296,13 @@ def check_known_cidrs(subnets, virsh_networks, maas_subnets):
     if unknown_in_virsh or unknown_in_maas:
         sys.exit(1)
 
+
+# TODO: add a check that the machine we are creating is on a subnet that is one
+#       of the managed cluster networks. Otherwise when the machine boots, it
+#       won't be able to PXE boot. Also, testing seems to indicate that eth0
+#       has to be the one PXE booting. I get "NO BOOTABLE DEVICES" if I make
+#       eth1 be on the 'maas' network.
+
 if __name__ == '__main__':
     settings = configure()
     virsh_networks = VirshNetwork.all_networks()

--- a/kmaas.py
+++ b/kmaas.py
@@ -272,6 +272,10 @@ def configure():
     with open(os.path.expanduser('~/.config/kvm_maas.yaml')) as f:
         settings = yaml.load(f)
 
+    if "_" in args.name:
+        print "MAAS does not allow '_' in machine names"
+        exit(1)
+
     settings['machine_name'] = args.name
     settings['template'] = args.template
     settings['subnets'] = args.subnet


### PR DESCRIPTION
MAAS doesn't let you create machines with "_" in their name, so we might as well reject it early so you don't have to go back and delete the virt machine. (this lets us keep the machine names in sync so you can track what is where.)
